### PR TITLE
Fix ort explicit providers required

### DIFF
--- a/deface/centerface.py
+++ b/deface/centerface.py
@@ -41,7 +41,7 @@ class CenterFace:
 
             static_model = onnx.load(onnx_path)
             dyn_model = self.dynamicize_shapes(static_model)
-            self.sess = onnxruntime.InferenceSession(dyn_model.SerializeToString())
+            self.sess = onnxruntime.InferenceSession(dyn_model.SerializeToString(), providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
 
             preferred_provider = self.sess.get_providers()[0]
             preferred_device = 'GPU' if preferred_provider.startswith('CUDA') else 'CPU'


### PR DESCRIPTION
Fix for #21 

I simply added the providers `CUDAExecutionProvider` and `CPUExecutionProvider` as arguments for the `onnxruntime.InferenceSession` class instantiation.