### PR TITLE
Fix crash when trying to keep audio but there's no audio stream

### DIFF
--- a/deface/deface.py
+++ b/deface/deface.py
@@ -149,7 +149,8 @@ def video_detect(
         _ffmpeg_config = ffmpeg_config.copy()
         #  If fps is not explicitly set in ffmpeg_config, use source video fps value
         _ffmpeg_config.setdefault('fps', meta['fps'])
-        if keep_audio:  # Carry over audio from input path, use "copy" codec (no transcoding) by default
+        # Carry over audio from input path, use "copy" codec (no transcoding) by default
+        if keep_audio and meta.get('audio_codec'):
             _ffmpeg_config.setdefault('audio_path', ipath)
             _ffmpeg_config.setdefault('audio_codec', 'copy')
         writer: imageio.plugins.ffmpeg.FfmpegFormat.Writer = imageio.get_writer(


### PR DESCRIPTION
When `keep_audio is True`, but there's no audio stream in the video, we get the following error:

```
0%|          | 0/2250 [00:00<?, ?it/s]Stream map '1:a:0' matches no streams.
To ignore this, add a trailing '?' to the map.

Traceback (most recent call last):
    File "/home/borijang/deface/lib/python3.9/site-packages/imageio_ffmpeg/_io.py", line 630, in write_frames
        p.stdin.write(bb)
    BrokenPipeError: [Errno 32] Broken pipe

FFMPEG COMMAND:
/home/borijang/deface/lib/python3.9/site-packages/imageio_ffmpeg/binaries/ffmpeg-linux64-v4.2.2 -y -f rawvideo -vcodec rawvideo -s 1280x720 -pix_fmt rgb24 -r 25.00 -i - -i vid2.mp4 -vcodec libx264 -pix_fmt yuv420p -v warning -acodec copy -map 0:v:0 -map 1:a:0 blur.mp4
```

This PR fixes this error by checking if `audio_codec` exists in the metadata, and only then attempts to keep the audio.